### PR TITLE
🎁 Allow RegEx patterns in options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import { IStyleAPI, IStyleItem } from 'import-sort-style'
 
 declare type ImportType = 'import' | 'require' | 'import-equals' | 'import-type'
@@ -41,14 +43,16 @@ export default function(
     let knownFirstparty = options.knownFirstparty || []
 
     function isFrameworkModule(imported: IImport) {
-        return knownFramework.some((prefix) =>
-            imported.moduleName.startsWith(prefix),
+        let [base] = imported.moduleName.split(path.sep)
+        return knownFramework.some((prefix: string) =>
+            RegExp(`${prefix}$`).test(base),
         )
     }
 
     function isFirstPartyModule(imported: IImport) {
-        return knownFirstparty.some((prefix) =>
-            imported.moduleName.startsWith(prefix),
+        let [base] = imported.moduleName.split(path.sep)
+        return knownFirstparty.some((prefix: string) =>
+            RegExp(`${prefix}$`).test(base),
         )
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "declaration": true,
 
+    "esModuleInterop": true,
     "lib": ["es2017"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Strings in `knownFramework` and `knownFirstparty` option
arrays can now include regular expression patterns.

💣 Options are now matched against only the first part of
the module path (i.e. up to the first `/`). This means 
something like `myapp` in `knownFirstparty` will match
`'myapp/subdir/foo'` but not `'myapp-addon/lib'`, where
previously it would have.